### PR TITLE
Update WordleMessageRegex.ts

### DIFF
--- a/src/Utils/WordleMessageRegex.ts
+++ b/src/Utils/WordleMessageRegex.ts
@@ -1,5 +1,5 @@
 function isWordleMessage(message: string): boolean  {
-    const regex = /^Wordle [0-9]+ [1-6|X][\/][6]\n\n([🟩|⬛|🟨|⬜]+[\n]?)+$/;
+    const regex = /^Wordle [0-9,]+ [1-6|X][\/][6]\n\n([🟩|⬛|🟨|⬜]+[\n]?)+$/;
     return regex.test(message);
 }
 


### PR DESCRIPTION
Wordle has passed 1000 games and the copied result message include a comma in the game number.  The regex that identifies a world message needs to be updated to account for the comma.